### PR TITLE
easy access to stash

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	haikunator "github.com/atrox/haikunatorgo"
-	"github.com/gin-gonic/contrib/sessions"
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
 

--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ func NewApp() *gin.Engine {
 		for _, file := range files {
 			stash = append(stash, file.Name())
 		}
-		c.JSON(200, gin.H{
-			"data": stash,
+		c.HTML(200, "stash.tmpl", gin.H{
+			"stash": stash,
 		})
 	})
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -38,3 +38,36 @@ body {
   width: 100%;
   border: none;
 }
+#stash-pane {
+  position: fixed;
+  top: 0;
+  width: 60%;
+  height: 100%;
+  font-size: 16px;
+}
+#stash-pane #controls {
+  color: #2e2e2e;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+  margin: 5px 5px 0 0;
+}
+#stash-pane #controls a {
+  font-weight: bold;
+  text-decoration: none;
+  color: #2e2e2e;
+}
+th, td {
+    text-align: left;
+    padding: 8px;
+     border-bottom: 1px solid #ddd;
+     font-size: 16px;
+}
+
+tr:nth-child(even){background-color: #f2f2f2}
+
+th {
+    background-color: #2e2e2e;
+    color: white;
+}

--- a/templates/stash.tmpl
+++ b/templates/stash.tmpl
@@ -1,6 +1,5 @@
-{{ define "index.tmpl" }}
-
-<!doctype html>
+{{ define "stash.tmpl"}}
+<!DOCTYPE html>
 <html lang="en">
 
     <head>
@@ -12,18 +11,29 @@
     </head>
 
     <body>
-        <div id="edit-pane">
+        <div id="stash-pane">
           <div id="controls">
           <a href="/stash" target="_blank" onclick="save();"> Stash</a> | 
             <a href="/published/{{ .pubTo}}" target="_blank" onclick="save();"> Present</a> |
             <a href="/published/{{ .pubTo}}?print-pdf" target="_blank" onclick="save();"> Pdf</a>
           </div>
-          <div id="editor"></div>
+          <div></div>
+          <div id ="list">
+          	<table>
+          		<tr>
+          			<th>Name</th>
+          			<th>Action</th>
+          		</tr>
+	          	{{range .stash}}
+	          		<tr>
+		          		<td><p>{{.}}</p></td>
+		          		<td><a href="/stash/edit/{{.}}" target ="_blank" onclick="save();">Edit</a></td>
+	          		</tr>
+	          	{{end}}
+          	</table>
+          </div>
         </div>
-        <div id="preview">
-            <iframe id="slides-frame" src="/published/{{ .pubTo}}?preview"></iframe>
-        </div>
-
+      
         <script src="/static/revealjs/js/ace-1.1.8/ace.js" type="text/javascript" charset="utf-8"></script>
         <script src="/static/revealjs/js/jquery-2.1.3.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/static/revealjs/js/jquery-debounce-1.0.5.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
list of old md files was hard to access. i added a link to index.tmpl near present and pdf links. 
this link gets /stash and displays old file list in a table with edit links near every file. 
edit links call to /stash/edit/:filename

by the way. gin-gonic/contrib/sessions [github page ](https://github.com/gin-gonic/contrib/tree/master/sessions) has an end of life notice. so i changed this to gin-contrib/sessions
